### PR TITLE
Create instance of HideWPToolbar if it doesn't exist.

### DIFF
--- a/hide-wp-toolbar.php
+++ b/hide-wp-toolbar.php
@@ -115,6 +115,7 @@ final class HideWPToolbar {
 			if ( ! defined( 'HideWPToolbar_PLUGIN_DIR' ) )
 				define( 'HideWPToolbar_PLUGIN_DIR',  plugin_dir_path( __FILE__ ) );
 			require_once HideWPToolbar_PLUGIN_DIR . 'class-hidewptoolbar-session.php';
+			self::$instance = new HideWPToolbar();
 			self::$instance->session = new HideWPToolbar_Session(); 
 		}
 


### PR DESCRIPTION
Hi.

I was getting an error:

```
Warning: Creating default object from empty value
Location: wp-content/plugins/hide-wp-toolbar/hide-wp-toolbar.php:119
```

Looks like HideWPToolbar isn't creating an instance of itself if one doesn't exist?

This PR fixes the warning for me.
